### PR TITLE
Use "pack.name" in manifest.json file as it is used in language(texts) file.

### DIFF
--- a/BP/manifest.json
+++ b/BP/manifest.json
@@ -1,7 +1,7 @@
 {
     "format_version": 2,
     "header": {
-        "name": "WorldEdit [BP]",
+        "name": "pack.name",
         "description": "pack.description",
         "uuid": "3cdb2ddf-662e-4f8f-a0a1-1293b91ccb2f",
         "version": [

--- a/RP/manifest.json
+++ b/RP/manifest.json
@@ -1,7 +1,7 @@
 {
     "format_version": 2,
     "header": {
-        "name": "WorldEdit [RP]",
+        "name": "pack.name",
         "description": "pack.description",
         "uuid": "e304a4eb-f0a0-4979-ac17-7b0f46a555c8",
         "version": [


### PR DESCRIPTION
Used line 5 which have "pack.description" as a samle, as I see there is "pack.name" in the language(texts) file, so maybe using it also in manifest.json file?