### PR TITLE
;kit command, and others...

### DIFF
--- a/src/server/commands/brush/brush.ts
+++ b/src/server/commands/brush/brush.ts
@@ -79,7 +79,7 @@ const sphere_command = (session: PlayerSession, builder: Player, brush: string, 
         args.get('pattern'),
         args.has('h')
     ));
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 };
 
 const cylinder_command = (session: PlayerSession, builder: Player, brush: string, args: Map<string, any>) => {
@@ -89,14 +89,14 @@ const cylinder_command = (session: PlayerSession, builder: Player, brush: string
         args.get('pattern'),
         args.has('h')
     ));
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 };
 
 const none_command = (session: PlayerSession, builder: Player, brush: string, args: Map<string, any>) => {
     if (session.hasTool(brush)) {
         session.unbindTool(brush);
     }
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 };
 
 commandList['brush'] = [registerInformation, (session, builder, args) => {

--- a/src/server/commands/brush/mask.ts
+++ b/src/server/commands/brush/mask.ts
@@ -23,9 +23,9 @@ const registerInformation = {
 commandList['mask'] = [registerInformation, (session, builder, args) => {
     const brush = getBrushTier(args);
     if (!session.hasTool(brush)) {
-        throw RawText.translate('worldedit.wand.brush.no-bind');
+        throw RawText.translate('commands.wedit:brush.noBind');
     }
     
     session.setToolProperty(brush, 'mask', args.get('mask'));
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 }];

--- a/src/server/commands/brush/range.ts
+++ b/src/server/commands/brush/range.ts
@@ -22,9 +22,9 @@ const registerInformation = {
 commandList['range'] = [registerInformation, (session, builder, args) => {
     const brush = getBrushTier(args);
     if (!session.hasTool(brush)) {
-        throw RawText.translate('worldedit.wand.brush.no-bind');
+        throw RawText.translate('commands.wedit:brush.noBind');
     }
     
     session.setToolProperty(brush, 'range', args.get('range'));
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 }];

--- a/src/server/commands/brush/size.ts
+++ b/src/server/commands/brush/size.ts
@@ -21,9 +21,9 @@ const registerInformation = {
 commandList['size'] = [registerInformation, (session, builder, args) => {
     const brush = getBrushTier(args);
     if (!session.hasTool(brush)) {
-        throw RawText.translate('worldedit.wand.brush.no-bind');
+        throw RawText.translate('commands.wedit:brush.noBind');
     }
     
     session.setToolProperty(brush, 'size', args.get('size'));
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 }];

--- a/src/server/commands/brush/tracemask.ts
+++ b/src/server/commands/brush/tracemask.ts
@@ -22,10 +22,10 @@ const registerInformation = {
 commandList['tracemask'] = [registerInformation, (session, builder, args) => {
     const brush = getBrushTier(args);
     if (!session.hasTool(brush)) {
-        throw RawText.translate('worldedit.wand.brush.no-bind');
+        throw RawText.translate('commands.wedit:brush.noBind');
     }
     
     const mask: Mask = args.get('mask');
     session.setToolProperty(brush, 'traceMask', mask.toString() ? mask : null);
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 }];

--- a/src/server/commands/clipboard/cut.ts
+++ b/src/server/commands/clipboard/cut.ts
@@ -1,6 +1,6 @@
 import { Player } from 'mojang-minecraft';
 import { Server } from '@library/Minecraft.js';
-import { assertBuilder } from '@modules/assert.js';
+import { assertCanBuildWithin } from '@modules/assert.js';
 
 import { getSession } from '../../sessions.js';
 import { Vector } from '@modules/vector.js';
@@ -36,15 +36,11 @@ commandList['cut'] = [registerInformation, (session, builder, args) => {
     const history = session.getHistory();
     history.record();
 
-    if (session.selectionMode == 'cuboid') {
-        const [pos1, pos2] = session.getSelectionPoints();
-        var start = Vector.min(pos1, pos2).toBlock();
-        var end = Vector.max(pos1, pos2).toBlock();
-        history.addUndoStructure(start, end, 'any');
-    }
+    const [start, end] = session.getSelectionRange();
+    history.addUndoStructure(start, end, 'any');
     
     if (copy(session, args)) {
-        throw RawText.translate('worldedit.error.command-fail');
+        throw RawText.translate('commands.generic.wedit:commandFail');
     }
 
     let pattern: Pattern = args.get('fill');
@@ -66,5 +62,5 @@ commandList['cut'] = [registerInformation, (session, builder, args) => {
     history.addRedoStructure(start, end, session.selectionMode == 'cuboid' ? 'any' : []);
     history.commit();
     
-    return RawText.translate('worldedit.cut.explain').with(`${session.getBlocksSelected().length}`);
+    return RawText.translate('commands.wedit:cut.explain').with(`${session.getBlocksSelected().length}`);
 }];

--- a/src/server/commands/clipboard/paste.ts
+++ b/src/server/commands/clipboard/paste.ts
@@ -1,6 +1,6 @@
 import { BlockLocation, Player } from 'mojang-minecraft';
 import { Server } from '@library/Minecraft.js';
-import { assertClipboard } from '@modules/assert.js';
+import { assertClipboard, assertCanBuildWithin } from '@modules/assert.js';
 import { getSession } from '../../sessions.js';
 
 import { Regions } from '@modules/regions.js';
@@ -40,13 +40,13 @@ commandList['paste'] = [registerInformation, (session, builder, args) => {
     let pasteEnd = Vector.add(pasteStart, Vector.sub(Regions.getSize('clipboard', builder), Vector.ONE)).toBlock();
     
     if (pasteContent) {
+        assertCanBuildWithin(PlayerUtil.getDimension(session.getPlayer())[1], pasteStart, pasteEnd);
         const history = session.getHistory();
         history.record();
         history.addUndoStructure(pasteStart, pasteEnd, 'any');
         
         if (Regions.load('clipboard', pasteStart, builder)) {
-            history.cancel();
-            throw RawText.translate('worldedit.error.command-fail');
+            throw RawText.translate('commands.generic.wedit:command-Fail');
         }
         
         history.addRedoStructure(pasteStart, pasteEnd, 'any');
@@ -61,7 +61,7 @@ commandList['paste'] = [registerInformation, (session, builder, args) => {
     }
     
     if (pasteContent) {
-        return RawText.translate('worldedit.paste.explain').with(`${Regions.getBlockCount('clipboard', builder)}`);
+        return RawText.translate('commands.wedit:paste.explain').with(`${Regions.getBlockCount('clipboard', builder)}`);
     }
     return '';
 }];

--- a/src/server/commands/generation/cyl.ts
+++ b/src/server/commands/generation/cyl.ts
@@ -69,5 +69,5 @@ commandList['cyl'] = [registerInformation, (session, builder, args) => {
     const cylShape = new CylinderShape(height, ...<[number, number]>radii);
     const count = cylShape.generate(loc, pattern, null, session, {'hollow': isHollow});
 
-    return RawText.translate('worldedit.generate.created').with(`${count}`);
+    return RawText.translate('commands.blocks.wedit:created').with(`${count}`);
 }];

--- a/src/server/commands/generation/pyramid.ts
+++ b/src/server/commands/generation/pyramid.ts
@@ -31,5 +31,5 @@ commandList['pyramid'] = [registerInformation, (session, builder, args) => {
     const pyramidShape = new PyramidShape(size);
     const count = pyramidShape.generate(loc, pattern, null, session, {'hollow': isHollow});
 
-    return RawText.translate('worldedit.generate.created').with(`${count}`);
+    return RawText.translate('commands.blocks.wedit:created').with(`${count}`);
 }];

--- a/src/server/commands/generation/sphere.ts
+++ b/src/server/commands/generation/sphere.ts
@@ -78,5 +78,5 @@ commandList['sphere'] = [registerInformation, (session, builder, args) => {
     const sphereShape = new SphereShape(...radii);
     const count = sphereShape.generate(loc, pattern, null, session, {'hollow': isHollow});
     
-    return RawText.translate('worldedit.generate.created').with(`${count}`);
+    return RawText.translate('commands.blocks.wedit:created').with(`${count}`);
 }];

--- a/src/server/commands/history/clearhistory.ts
+++ b/src/server/commands/history/clearhistory.ts
@@ -9,5 +9,5 @@ const registerInformation = {
 commandList['clearhistory'] = [registerInformation, (session, builder, args) => {
     const history = session.getHistory();
     history.clear();
-    return RawText.translate('worldedit.clearhistory.cleared');
+    return RawText.translate('commands.wedit:clearhistory.explain');
 }];

--- a/src/server/commands/history/redo.ts
+++ b/src/server/commands/history/redo.ts
@@ -24,9 +24,8 @@ commandList['redo'] = [registerInformation, (session, builder, args) => {
     const history = session.getHistory();
     for(var i = 0; i < times; i++) {
         if (history.redo()) {
-                break;
+            break;
         }
     }
-    
-    return RawText.translate(i == 0 ? 'worldedit.redo.none' : 'worldedit.redo.redone').with(`${i}`);
+    return RawText.translate(i == 0 ? 'commands.wedit:redo.none' : 'commands.wedit:redo.explain').with(`${i}`);
 }];

--- a/src/server/commands/history/undo.ts
+++ b/src/server/commands/history/undo.ts
@@ -24,8 +24,8 @@ commandList['undo'] = [registerInformation, (session, builder, args) => {
     const history = session.getHistory();
     for(var i = 0; i < times; i++) {
         if (history.undo()) {
-                break;
+            break;
         }
     }
-    return RawText.translate(i == 0 ? 'worldedit.undo.none' : 'worldedit.undo.undone').with(`${i}`);
+    return RawText.translate(i == 0 ? 'commands.wedit:undo.none' : 'commands.wedit:undo.explain').with(`${i}`);
 }];

--- a/src/server/commands/import-commands.ts
+++ b/src/server/commands/import-commands.ts
@@ -17,6 +17,7 @@ Server.command.addCustomArgType('Pattern', Pattern);
 Server.command.addCustomArgType('Direction', Cardinal);
 
 import './misc/help.js';
+import './misc/kit.js';
 
 import './selection/pos1.js';
 import './selection/pos2.js';

--- a/src/server/commands/misc/help.ts
+++ b/src/server/commands/misc/help.ts
@@ -66,7 +66,7 @@ commandList['help'] = [registerInformation, (session, builder, args) => {
         let page: number = Math.max(args.get('page'), 1);
         let pageOff = (Math.min(page, totalPages) - 1) * PAGE_SIZE;
         
-        let msg = RawText.text('§2').append('translate', 'worldedit.help.header').with(`${pageOff / PAGE_SIZE + 1}`).with(`${totalPages}`).append('text', '§r');
+        let msg = RawText.text('§2').append('translate', 'commands.wedit:help.header').with(`${pageOff / PAGE_SIZE + 1}`).with(`${totalPages}`).append('text', '§r');
         for (let i = pageOff; i < Math.min(pageOff + PAGE_SIZE, cmdInfo.length); i++) {
             const cmd = cmdInfo[i];
             msg.append('text', `\n${Server.command.prefix}${cmd[0]} ${cmd[1]}`);

--- a/src/server/commands/misc/kit.ts
+++ b/src/server/commands/misc/kit.ts
@@ -1,0 +1,35 @@
+import { Server } from '@library/Minecraft.js';
+import { commandList } from '../command_list.js';
+import { RawText } from '@modules/rawtext.js';
+
+const registerInformation = {
+    name: 'kit',
+    description: 'commands.wedit:kit.description'
+};
+
+commandList['kit'] = [registerInformation, (session, builder, args) => {
+    const items = [
+        'wedit:selection_wand',
+        'wedit:selection_fill',
+        'wedit:pattern_picker',
+        'wedit:copy_button',
+        'wedit:cut_button',
+        'wedit:paste_button',
+        'wedit:undo_button',
+        'wedit:redo_button',
+        'wedit:spawn_glass',
+        
+        'wedit:flip_button',
+        'wedit:rotate_cw_button',
+        'wedit:rotate_ccw_button',
+        'wedit:config_button'
+    ];
+    
+    for (const item of items) {
+        if (Server.runCommand(`clear "${builder.nameTag}" ${item} -1 0`).error) {
+            Server.runCommand(`give "${builder.nameTag}" ${item}`);
+        }
+    }
+    
+    return RawText.translate('commands.wedit:kit.explain');
+}];

--- a/src/server/commands/navigation/jumpto.ts
+++ b/src/server/commands/navigation/jumpto.ts
@@ -21,8 +21,8 @@ commandList['jumpto'] = [registerInformation, (session, builder, args) => {
     const dir = PlayerUtil.getDirection(builder);
     const hit = raytrace(dimension, origin, dir);
     if (!hit || Server.runCommand(`tp "${builder.nameTag}" ${printLocation(hit, false)}`, dimension).error) {
-        throw RawText.translate('worldedit.jumpto.none');
+        throw RawText.translate('commands.wedit:jumpto.none');
     }
     commandList['unstuck'][1](session, builder, new Map());
-    return RawText.translate('worldedit.jumpto.moved');
+    return RawText.translate('commands.wedit:jumpto.explain');
 }];

--- a/src/server/commands/navigation/navwand.ts
+++ b/src/server/commands/navigation/navwand.ts
@@ -12,5 +12,5 @@ commandList['navwand'] = [registerInformation, (session, builder, args) => {
     const dimension = PlayerUtil.getDimension(builder)[1];
     Server.runCommand(`clear "${builder.nameTag}" wedit:navigation_wand`, dimension);
     Server.runCommand(`give "${builder.nameTag}" wedit:navigation_wand`, dimension);
-    return RawText.translate('worldedit.wand.navwand.info');
+    return RawText.translate('commands.wedit:navwand.explain');
 }];

--- a/src/server/commands/navigation/thru.ts
+++ b/src/server/commands/navigation/thru.ts
@@ -23,7 +23,7 @@ commandList['thru'] = [registerInformation, (session, builder, args) => {
 
     let testLoc = blockLoc.offset(dir.x, dir.y, dir.z);
     if (isSpaceEmpty(testLoc)) {
-        throw RawText.translate('worldedit.thru.none');
+        throw RawText.translate('commands.wedit:thru.none');
     }
 
     let canGoThrough = false;
@@ -37,8 +37,8 @@ commandList['thru'] = [registerInformation, (session, builder, args) => {
 
     if (canGoThrough) {
         Server.runCommand(`tp "${builder.nameTag}" ${printLocation(testLoc, false)}`, dimName);
-        return RawText.translate('worldedit.thru.moved');
+        return RawText.translate('commands.wedit:thru.explain');
     } else {
-        throw RawText.translate('worldedit.thru.obstructed');
+        throw RawText.translate('commands.wedit:thru.obstructed');
     }
 }];

--- a/src/server/commands/navigation/unstuck.ts
+++ b/src/server/commands/navigation/unstuck.ts
@@ -22,5 +22,5 @@ commandList['unstuck'] = [registerInformation, (session, builder, args) => {
     while (blockLoc.y += 1);
 
     Server.runCommand(`tp "${builder.nameTag}" ${printLocation(blockLoc, false)}`, dimName);
-    return RawText.translate('worldedit.unstuck.moved');
+    return RawText.translate('commands.wedit:unstuck.explain');
 }];

--- a/src/server/commands/navigation/up.ts
+++ b/src/server/commands/navigation/up.ts
@@ -30,5 +30,5 @@ commandList['up'] = [registerInformation, (session, builder, args) => {
 
     Server.runCommand(`tp "${builder.nameTag}" ${printLocation(blockLoc, false)}`, dimName);
     Server.runCommand(`setblock ${printLocation(blockLoc.offset(0, -1, 0), false)} glass`, dimName);
-    return RawText.translate('worldedit.up.moved');
+    return RawText.translate('commands.wedit:up.explain');
 }];

--- a/src/server/commands/region/replace.ts
+++ b/src/server/commands/region/replace.ts
@@ -1,6 +1,7 @@
 import { PlayerSession } from '../../sessions.js';
 import { Vector } from '@modules/vector.js';
 import { PlayerUtil } from '@modules/player_util.js';
+import { assertSelection, assertCanBuildWithin } from '@modules/assert.js';
 import { Pattern } from '@modules/pattern.js';
 import { commandList } from '../command_list.js';
 import { RawText } from '@modules/rawtext.js';
@@ -33,9 +34,8 @@ function getAffectedBlocks(session: PlayerSession, mask: Mask) {
 }
 
 commandList['replace'] = [registerInformation, (session, builder, args) => {
-    if (session.getBlocksSelected().length == 0) {
-        throw 'You need to make a selection to replace!';
-    }
+    assertSelection(session);
+    assertCanBuildWithin(PlayerUtil.getDimension(session.getPlayer())[1], ...session.getSelectionRange());
     
     const mask = args.get('mask');
     const pattern = session.usingItem ? session.globalPattern : args.get('pattern');
@@ -63,5 +63,5 @@ commandList['replace'] = [registerInformation, (session, builder, args) => {
     history.addRedoStructure(start, end, affectedBlocks);
     history.commit();
 
-    return RawText.translate('worldedit.set.changed').with(`${count}`);
+    return RawText.translate('commands.blocks.wedit:changed').with(`${count}`);
 }];

--- a/src/server/commands/region/set.ts
+++ b/src/server/commands/region/set.ts
@@ -1,5 +1,6 @@
 import { PlayerSession } from '../../sessions.js';
 import { printDebug } from '../../util.js';
+import { assertSelection, assertCanBuildWithin } from '@modules/assert.js';
 import { Vector } from '@modules/vector.js';
 import { PlayerUtil } from '@modules/player_util.js';
 import { Pattern } from '@modules/pattern.js';
@@ -39,11 +40,10 @@ export function set(session: PlayerSession, pattern: Pattern, mask?: Mask) {
 }
 
 commandList['set'] = [registerInformation, (session, builder, args) => {
-    if (session.getBlocksSelected().length == 0) {
-        throw 'You need to make a selection to set!';
-    }
+    assertSelection(session);
+    assertCanBuildWithin(PlayerUtil.getDimension(session.getPlayer())[1], ...session.getSelectionRange());
     if (session.usingItem && !session.globalPattern.toString()) {
-        throw 'You need to specify a block to set the selection to!';
+        throw RawText.translate('worldEdit.selectionFill.noPattern');
     }
     
     const pattern = session.usingItem ? session.globalPattern : args.get('pattern');
@@ -63,5 +63,5 @@ commandList['set'] = [registerInformation, (session, builder, args) => {
     history.addRedoStructure(start, end, session.selectionMode == 'cuboid' ? 'any' : []);
     history.commit();
 
-    return RawText.translate('worldedit.set.changed').with(`${count}`);
+    return RawText.translate('commands.blocks.wedit:changed').with(`${count}`);
 }];

--- a/src/server/commands/selection/drawsel.ts
+++ b/src/server/commands/selection/drawsel.ts
@@ -9,8 +9,8 @@ const registerInformation = {
 commandList['drawsel'] = [registerInformation, (session, builder, args) => {
     session.drawSelection = !session.drawSelection;
     if (session.drawSelection) {
-        return RawText.translate('worldedit.drawsel.enabled');
+        return RawText.translate('commands.wedit:drawsel.enabled');
     } else {
-        return RawText.translate('worldedit.drawsel.disabled');;
+        return RawText.translate('commands.wedit:drawsel.disabled');;
     }
 }];

--- a/src/server/commands/selection/wand.ts
+++ b/src/server/commands/selection/wand.ts
@@ -14,5 +14,5 @@ commandList['wand'] = [registerInformation, (session, builder, args) => {
     const dimension = PlayerUtil.getDimension(builder)[1];
     Server.runCommand(`clear "${builder.nameTag}" wedit:selection_wand`, dimension);
     Server.runCommand(`give "${builder.nameTag}" wedit:selection_wand`, dimension);
-    return RawText.translate('worldedit.wand.selwand.info');
+    return RawText.translate('commands.wedit:wand.explain');
 }];

--- a/src/server/commands/tool/tool.ts
+++ b/src/server/commands/tool/tool.ts
@@ -36,7 +36,7 @@ const stack_command = (session: PlayerSession, builder: Player, args: Map<string
     if (!PlayerUtil.hasItem(builder, 'wedit:stacker_wand') && !PlayerUtil.hasItem(builder, 'minecraft:iron_axe')) {
         Server.runCommand(`give "${builder.nameTag}" iron_axe`, dimension);
     }
-    return RawText.translate('worldedit.wand.generic.info');
+    return RawText.translate('commands.generic.wedit:wandInfo');
 };
 
 commandList['tool'] = [registerInformation, (session, builder, args) => {

--- a/src/server/modules/assert.ts
+++ b/src/server/modules/assert.ts
@@ -1,23 +1,44 @@
-import { Player } from 'mojang-minecraft';
+import { Player, BlockLocation } from 'mojang-minecraft';
 import { Server } from '@library/Minecraft.js';
+import { dimension } from '@library/@types/index.js';
 import { RawText } from './rawtext.js';
 import { Regions } from './regions.js';
+import { Vector } from './vector.js';
 import { PlayerSession } from '../sessions.js';
+import { canPlaceBlock, printDebug } from '../util.js';
 
 export function assertBuilder(player: Player) {
     if (!Server.player.hasTag('builder', player.nameTag)) {
-        throw RawText.translate('commands.generic.wedit:no-perms');
+        throw RawText.translate('commands.generic.wedit:noPermission');
+    }
+}
+
+export function assertCanBuildWithin(dim: dimension, min: BlockLocation, max: BlockLocation) {
+    const minChunk = Vector.from(min).mul(1/16).floor().mul(16);
+    const maxChunk = Vector.from(max).mul(1/16).ceil().mul(16);
+    
+    for (let z = minChunk.z; z < maxChunk.z; z += 16)
+    for (let x = minChunk.x; x < maxChunk.x; x += 16) {
+        if (!canPlaceBlock(new BlockLocation(x, 0, z), dim)) {
+            throw RawText.translate('commands.generic.wedit:outsideWorld');
+        }
     }
 }
 
 export function assertClipboard(player: Player) {
     if (!Regions.has('clipboard', player)) {
-        throw RawText.translate('commands.generic.wedit:no-clipboard');
+        throw RawText.translate('commands.generic.wedit:noClipboard');
+    }
+}
+
+export function assertSelection(session: PlayerSession) {
+    if (session.getBlocksSelected().length == 0) {
+        throw RawText.translate('commands.generic.wedit:noSelection');
     }
 }
 
 export function assertCuboidSelection(session: PlayerSession) {
     if (session.getBlocksSelected().length == 0 || session.selectionMode != 'cuboid') {
-        throw RawText.translate('commands.generic.wedit:no-cuboid-region');
+        throw RawText.translate('commands.generic.wedit:noCuboidSelection');
     }
 }

--- a/src/server/modules/directions.ts
+++ b/src/server/modules/directions.ts
@@ -42,7 +42,7 @@ export class Cardinal implements CustomArgType {
     static parseArgs(args: Array<string>, index = 0) {
         const dir = args[index][0].toLowerCase();
         if (!directions.includes(dir) && !dirAliases.includes(dir)) {
-            throw RawText.translate('commands.generic.invalidDir').with(args[index]);
+            throw RawText.translate('commands.generic.wedit:invalidDir').with(args[index]);
             /*printDebug(dir);
             printDebug(dir in directions);*/
         }

--- a/src/server/modules/player_util.ts
+++ b/src/server/modules/player_util.ts
@@ -14,24 +14,24 @@ class PlayerHandler extends EventEmitter {
     constructor() {
         super();
         Server.on('tick', tick => {
-                for (const entry of this.playerDimensions) {
-                    entry[1][0] = false;
-                }
+            for (const entry of this.playerDimensions) {
+                entry[1][0] = false;
+            }
+            
+            for (const player of World.getPlayers()) {
+                const oldDimension = this.playerDimensions.get(player.nameTag)?.[2];
+                const newDimension = this.getDimension(player)[1];
                 
-                for (const player of World.getPlayers()) {
-                    const oldDimension = this.playerDimensions.get(player.nameTag)?.[2];
-                    const newDimension = this.getDimension(player)[1];
-                    
-                    if (oldDimension && oldDimension != newDimension) {
-                        this.emit('playerChangeDimension', player, newDimension);
-                    }
+                if (oldDimension && oldDimension != newDimension) {
+                    this.emit('playerChangeDimension', player, newDimension);
                 }
+            }
         });
         this.on('playerChangeDimension', (player, dimension) => {
-                // Teleport the inventory stasher with the player
-                printDebug(`"${player.nameTag}" has travelled to "${dimension}"`);
-                const stasherName = 'wedit:stasher_for_' + player.nameTag;
-                Server.runCommand(`execute "${player.nameTag}" ~~~ tp @e[name="${stasherName}"] ~ 512 ~`, dimension);
+            // Teleport the inventory stasher with the player
+            printDebug(`"${player.nameTag}" has travelled to "${dimension}"`);
+            const stasherName = 'wedit:stasher_for_' + player.nameTag;
+            Server.runCommand(`execute "${player.nameTag}" ~~~ tp @e[name="${stasherName}"] ~ 512 ~`, dimension);
         });
     }
     
@@ -55,15 +55,15 @@ class PlayerHandler extends EventEmitter {
     replaceItem(player: Player, item: string, sub: string) {
         const inv = player.getComponent('inventory').container;
         for (let i = 0; i < inv.size; i++) {
-                if (inv.getItem(i)?.id === item) {
-                    const slotType = i > 8 ? 'slot.inventory' : 'slot.hotbar';
-                    const slotId = i > 8 ? i - 9 : i;
-                    // printDebug(slotId);
-                    // printDebug(slotType);
-                    // printDebug(item + ' -> ' + sub);
-                    Server.runCommand(`replaceitem entity "${player.nameTag}" ${slotType} ${slotId} ${sub}`);
-                    break;
-                }
+            if (inv.getItem(i)?.id === item) {
+                const slotType = i > 8 ? 'slot.inventory' : 'slot.hotbar';
+                const slotId = i > 8 ? i - 9 : i;
+                // printDebug(slotId);
+                // printDebug(slotType);
+                // printDebug(item + ' -> ' + sub);
+                Server.runCommand(`replaceitem entity "${player.nameTag}" ${slotType} ${slotId} ${sub}`);
+                break;
+            }
         }
     }
     
@@ -118,19 +118,19 @@ class PlayerHandler extends EventEmitter {
     */
     getDimension(player: Player): [Dimension, dimension] {
         if (this.playerDimensions.get(player.nameTag)?.[0]) {
-                return <[Dimension, dimension]> this.playerDimensions.get(player.nameTag).slice(1);
+            return <[Dimension, dimension]> this.playerDimensions.get(player.nameTag).slice(1);
         }
     
         const blockLoc = this.getBlockLocation(player);
         for (const dimName of <dimension[]> ['overworld', 'nether', 'the end']) {
-                const dimension: Dimension = World.getDimension(dimName);
-                const entities: Entity[] = dimension.getEntitiesAtBlockLocation(blockLoc);
-                for (const entity of entities) {
-                    if (entity.id == 'minecraft:player' && entity.nameTag == player.nameTag) {
-                        this.playerDimensions.set(player.nameTag, [true, dimension, dimName]);
-                        return [dimension, dimName];
-                    }
+            const dimension: Dimension = World.getDimension(dimName);
+            const entities: Entity[] = dimension.getEntitiesAtBlockLocation(blockLoc);
+            for (const entity of entities) {
+                if (entity.id == 'minecraft:player' && entity.nameTag == player.nameTag) {
+                    this.playerDimensions.set(player.nameTag, [true, dimension, dimName]);
+                    return [dimension, dimName];
                 }
+            }
         }
         return <[Dimension, dimension]> this.playerDimensions.get(player.nameTag).slice(1) || [null, null];
     }
@@ -151,7 +151,7 @@ class PlayerHandler extends EventEmitter {
     */
     stashHotbar(player: Player) {
         if (this.isHotbarStashed(player)) {
-                return true;
+            return true;
         }
         
         const stasher = this.getDimension(player)[0].spawnEntity('wedit:inventory_stasher', new BlockLocation(player.location.x, 512, player.location.z));
@@ -160,7 +160,7 @@ class PlayerHandler extends EventEmitter {
         const inv: InventoryComponentContainer = player.getComponent('inventory').container;
         const inv_stash: InventoryComponentContainer = stasher.getComponent('inventory').container;
         for (let i = 0; i < 9; i++) {
-                inv.transferItem(i, i, inv_stash);
+            inv.transferItem(i, i, inv_stash);
         }
         return false;
     }
@@ -176,30 +176,30 @@ class PlayerHandler extends EventEmitter {
         const stasherName = 'wedit:stasher_for_' + player.nameTag;
         Server.runCommand(`execute "${player.nameTag}" ~~~ tp @e[name="${stasherName}"] ~ 512 ~`, dimension);
         for (const entity of World.getDimension(dimension).getEntitiesAtBlockLocation(new BlockLocation(Math.floor(player.location.x), 512, Math.floor(player.location.z)))) {
-                if (entity.nameTag == stasherName) {
-                    stasher = entity;
-                    break;
-                }
+            if (entity.nameTag == stasherName) {
+                stasher = entity;
+                break;
+            }
         }
         
         if (stasher) {
-                const inv: InventoryComponentContainer = player.getComponent('inventory').container;
-                const inv_stash: InventoryComponentContainer = stasher.getComponent('inventory').container;
-                for (let i = 0; i < 9; i++) {
-                    if (inv.getItem(i) && inv_stash.getItem(i)) {
-                        inv.swapItems(i, i, inv_stash);
-                    } else if (inv.getItem(i)) {
-                        inv.transferItem(i, i, inv_stash);
-                    } else {
-                        inv_stash.transferItem(i, i, inv);
-                    }
+            const inv: InventoryComponentContainer = player.getComponent('inventory').container;
+            const inv_stash: InventoryComponentContainer = stasher.getComponent('inventory').container;
+            for (let i = 0; i < 9; i++) {
+                if (inv.getItem(i) && inv_stash.getItem(i)) {
+                    inv.swapItems(i, i, inv_stash);
+                } else if (inv.getItem(i)) {
+                    inv.transferItem(i, i, inv_stash);
+                } else {
+                    inv_stash.transferItem(i, i, inv);
                 }
-                Server.runCommand(`tp @e[name="${stasherName}"] ~ -256 ~`, dimension);
-                stasher.triggerEvent('wedit:kill');
-                stasher.nameTag = 'wedit:killed';
-                return false;
+            }
+            Server.runCommand(`tp @e[name="${stasherName}"] ~ -256 ~`, dimension);
+            stasher.triggerEvent('wedit:kill');
+            stasher.nameTag = 'wedit:killed';
+            return false;
         } else {
-                return true;
+            return true;
         }
     }
 }

--- a/src/server/shapes/base_shape.ts
+++ b/src/server/shapes/base_shape.ts
@@ -4,6 +4,7 @@ import { Mask } from '@modules/mask.js';
 import { PlayerSession } from '../sessions.js';
 import { PlayerUtil } from '@modules/player_util.js';
 import { Vector } from '@modules/vector.js';
+import { assertCanBuildWithin } from '@modules/assert.js';
 import { getWorldMinY, getWorldMaxY } from '../util.js';
 
 export type shapeGenOptions = {
@@ -63,7 +64,8 @@ export abstract class Shape {
         const maxY = getWorldMaxY(session.getPlayer());
         max.y = Math.min(maxY, max.y);
         let canGenerate = max.y >= min.y;
-    
+        
+        assertCanBuildWithin(dimension, min, max);
         const blocksAffected = [];
         mask = mask ?? new Mask();
         

--- a/src/server/tools/button_tools.ts
+++ b/src/server/tools/button_tools.ts
@@ -86,7 +86,7 @@ class SpawnGlassTool extends Tool {
     itemTool = 'wedit:spawn_glass';
     use = (player: Player, session: PlayerSession) => {
         if (Server.runCommand(`execute "${player.nameTag}" ~~~ setblock ~~~ glass`).error) {
-                throw RawText.translate('worldedit.spawn-glass.error');
+                throw RawText.translate('worldedit.spawnGlass.error');
         }
     }
 }

--- a/src/server/tools/picker_tool.ts
+++ b/src/server/tools/picker_tool.ts
@@ -32,7 +32,7 @@ class PatternPickerTool extends Tool {
         if (blockName.startsWith('minecraft:')) {
             blockName = blockName.slice('minecraft:'.length);
         }
-        this.log(RawText.translate('worldedit.pattern-picker.' + (addedToPattern ? 'add' : 'set'))
+        this.log(RawText.translate('worldedit.patternPicker.' + (addedToPattern ? 'add' : 'set'))
             .append('text', blockName)
         );
     }
@@ -44,7 +44,7 @@ class PatternPickerTool extends Tool {
             addedToPattern = false;
         }
         session.globalPattern.addBlock(MinecraftBlockTypes.air.createDefaultBlockPermutation());
-        this.log(RawText.translate('worldedit.pattern-picker.' + (addedToPattern ? 'add' : 'set'))
+        this.log(RawText.translate('worldedit.patternPicker.' + (addedToPattern ? 'add' : 'set'))
             .append('text', 'air')
         );
     }
@@ -79,7 +79,7 @@ class MaskPickerTool extends Tool {
         if (blockName.startsWith('minecraft:')) {
             blockName = blockName.slice('minecraft:'.length);
         }
-        this.log(RawText.translate('worldedit.mask-picker.' + (addedToPattern ? 'add' : 'set'))
+        this.log(RawText.translate('worldedit.maskPicker.' + (addedToPattern ? 'add' : 'set'))
             .append('text', blockName)
         );
     }
@@ -91,7 +91,7 @@ class MaskPickerTool extends Tool {
             addedToPattern = false;
         }
         session.globalMask.addBlock(MinecraftBlockTypes.air.createDefaultBlockPermutation());
-        this.log(RawText.translate('worldedit.mask-picker.' + (addedToPattern ? 'add' : 'set'))
+        this.log(RawText.translate('worldedit.maskPicker.' + (addedToPattern ? 'add' : 'set'))
             .append('text', 'air')
         );
     }

--- a/src/server/tools/selection_tool.ts
+++ b/src/server/tools/selection_tool.ts
@@ -14,24 +14,5 @@ class SelectionTool extends Tool {
             [`${loc.x}`, `${loc.y}`, `${loc.z}`]
         );
     }
-    
-    bind(player: Player) {
-        super.bind(player);
-        function giveItem(item: string) {
-            if (Server.runCommand(`clear "${player.nameTag}" ${item} -1 0`).error) {
-                Server.runCommand(`give "${player.nameTag}" ${item}`);
-            }
-        }
-        
-        giveItem('wedit:selection_fill');
-        giveItem('wedit:pattern_picker');
-        giveItem('wedit:copy_button');
-        giveItem('wedit:cut_button');
-        giveItem('wedit:paste_button');
-        giveItem('wedit:undo_button');
-        giveItem('wedit:redo_button');
-        giveItem('wedit:spawn_glass');
-        giveItem('wedit:config_button');
-    }
 }
 Tools.register(SelectionTool, 'selection_wand');

--- a/src/server/tools/stacker_tool.ts
+++ b/src/server/tools/stacker_tool.ts
@@ -26,18 +26,18 @@ class StackerTool extends Tool {
         }
         let end = loc;
         for (var i = 0; i < this.range; i++) {
-                end = end.offset(dir.x, dir.y, dir.z);
-                if (!this.mask.matchesBlock(end.offset(dir.x, dir.y, dir.z), dimName)) break;
+            end = end.offset(dir.x, dir.y, dir.z);
+            if (!this.mask.matchesBlock(end.offset(dir.x, dir.y, dir.z), dimName)) break;
         }
         const history = session.getHistory();
         history.record();
         history.addUndoStructure(start, end, 'any');
         
-        Regions.save('temp_stack', loc, loc, player);
+        Regions.save('tempStack', loc, loc, player);
         for (const pos of start.blocksBetween(end)) {
-                Regions.load('temp_stack', pos, player);
+            Regions.load('tempStack', pos, player);
         }
-        Regions.delete('temp_stack', player);
+        Regions.delete('tempStack', player);
         
         history.addRedoStructure(start, end, 'any');
         history.commit();

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -114,9 +114,11 @@ export function getWorldMaxY(player: Player) {
  */
 export function canPlaceBlock(loc: BlockLocation, dim: dimension) {
     const locString = printLocation(loc, false);
-    Server.runCommand(`structure save canPlaceHere ${locString} ${locString} false memory`, dim);
-    const error = Server.runCommand(`structure load canPlaceHere ${locString}`, dim).error;
-    Server.runCommand(`structure delete canPlaceHere ${locString}`, dim);
+    let error = Server.runCommand(`structure save canPlaceHere ${locString} ${locString} false memory`, dim).error;
+    if (!error) {
+        error = Server.runCommand(`structure load canPlaceHere ${locString}`, dim).error;
+        Server.runCommand(`structure delete canPlaceHere ${locString}`, dim);
+    }
     return !error;
 }
 


### PR DESCRIPTION
The `;kit` command is a command that replaces the function of taking a wooden axe from the inventory. It's more intuitive, and less intrusive.

Also, the translation keys have been modified to be closer to Bedrock's way of making these keys.

And a new function `assertCanBuildWithin` has been made and used to ensure that edits are only made in loaded chunks. Whether it be by distance from a player, or ticking areas.