### PR TITLE
Unknown command error message parity

### DIFF
--- a/src/library/Minecraft.ts
+++ b/src/library/Minecraft.ts
@@ -94,7 +94,7 @@ class ServerBuild extends ServerBuilder {
       const getCommand = Command.getAllRegistation().some(element => element.name === command || element.aliases && element.aliases.includes(command));
       if(!getCommand) {
         data.cancel = true;
-        RawText.translate("commands.generic.unknown").with(`§f${command}§c`).printError(data.sender);
+        RawText.translate("commands.generic.unknown").with(`${command}`).printError(data.sender);
         return;
       }
 


### PR DESCRIPTION
Changed the color of the command name in the error message for unknown commands from white to red as suggested by a member of the Discord server