### PR TITLE
Fix blank blank chat messages appearing when using selection wand

### DIFF
--- a/src/server/commands/register_commands.ts
+++ b/src/server/commands/register_commands.ts
@@ -34,7 +34,7 @@ export function registerCommand(registerInformation: CommandInfo, callback: comm
         }
         const time = timer.end();
         contentLog.log(`Time taken to execute: ${time}ms (${time / 1000.0} secs)`);
-        print(result, player, toActionBar);
+        if (result) print(result, player, toActionBar);
       }
       catch (e) {
         const errMsg = e.message ? `${e.name}: ${e.message}` : e;


### PR DESCRIPTION
I noticed that worldedit prints an empty chat message when selecting a block that is already selected. I fixed this by making it check wether the command result is empty or not before printing it.
https://user-images.githubusercontent.com/81803926/200572840-1f7768b3-36e5-46cf-97a4-c2cb7f49c4d9.mp4
