### PR TITLE
1.19.60 Support + Stack and Move upgrades + version bump

### DIFF
--- a/app/Main.tscn
+++ b/app/Main.tscn
@@ -151,7 +151,7 @@ margin_bottom = 43.0
 rect_min_size = Vector2( 0, 40 )
 size_flags_horizontal = 3
 size_flags_vertical = 12
-text = "0.7.0"
+text = "0.7.1"
 align = 2
 valign = 1
 

--- a/app/biome_height_data.gd
+++ b/app/biome_height_data.gd
@@ -98,6 +98,8 @@ func load_from_db(leveldb: LevelDB, mutex: Mutex = null) -> void:
 
 
 func save_to_db(leveldb: LevelDB, mutex: Mutex = null) -> int:
+	if height_limit <= 0: return OK
+	
 # warning-ignore:narrowing_conversion
 	var key = _to_int32(coord.x)
 # warning-ignore:narrowing_conversion

--- a/app/mc_world.gd
+++ b/app/mc_world.gd
@@ -160,7 +160,10 @@ func set_biome(dimension: String, loc: Vector3, biome: int) -> void:
 			data.min_height = -64
 		data.load_from_db(_leveldb)
 		_biome_height_data[key] = data
-	(_biome_height_data[key] as BiomeHeightData).set_biome(int(loc.x) % 16, int(loc.y), int(loc.z) % 16, biome)
+	
+	var data: BiomeHeightData = _biome_height_data[key]
+	if data.height_limit > 0:
+		data.set_biome(int(loc.x) % 16, int(loc.y), int(loc.z) % 16, biome)
 
 
 func _dimesnion2id(dimension: String) -> int:

--- a/mc_manifest.json
+++ b/mc_manifest.json
@@ -9,7 +9,7 @@
         "bp_uuid": "3cdb2ddf-662e-4f8f-a0a1-1293b91ccb2f",
 		"rp_uuid": "e304a4eb-f0a0-4979-ac17-7b0f46a555c8",
 		
-        "version": [ 0, 7, 0 ],
+        "version": [ 0, 7, 1 ],
 		"min_engine_version": [ 1, 19, 50 ]
 	},
 	"bp_modules": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
             "name": "worldedit",
             "license": "GPL-3.0-or-later",
             "dependencies": {
-                "@minecraft/server": "^1.1.0-beta.11950b23",
-                "@minecraft/server-ui": "^1.0.0-beta.11950b23"
+                "@minecraft/server": "^1.1.0-beta.1.19.60-preview.26",
+                "@minecraft/server-ui": "^1.0.0-beta.1.19.60-preview.26"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.33.0",
@@ -68,16 +68,16 @@
             "dev": true
         },
         "node_modules/@minecraft/server": {
-            "version": "1.1.0-beta.preview.1.19.50.21",
-            "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.preview.1.19.50.21.tgz",
-            "integrity": "sha512-ZA/96cHfmRE9RVajlI/HQDmTNiyF4Esjh+xJJ1wto3s1MISkDBlqf2gZbPZdwuRE3cMcONxFDzEXNiHu21FwtQ=="
+            "version": "1.1.0-beta.1.19.60-preview.26",
+            "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-preview.26.tgz",
+            "integrity": "sha512-SR8xaw6tTIAsdJuXcpqYiQd8EAtH8QYQPIKlTjqBZEJcQ8HCBxD5kBAECjYBseTnUIOoJx7UOo7nY7CmvKLjoA=="
         },
         "node_modules/@minecraft/server-ui": {
-            "version": "1.0.0-beta.preview.1.19.50.21",
-            "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-1.0.0-beta.preview.1.19.50.21.tgz",
-            "integrity": "sha512-/nsa+0NLS4KtgFE9KkVHINEcwwEeGcU8ps09CfOEK36fdS9vaiNNxsssTlncus+Cse6tSGrl02F0sH1LUbh+pQ==",
+            "version": "1.0.0-beta.1.19.60-preview.26",
+            "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-1.0.0-beta.1.19.60-preview.26.tgz",
+            "integrity": "sha512-oZoZlCVh94mgMiQjlmg2aA9b88M0zd4R0QeOJGi/2dhRrhqn1y979SpTlISY4uMeT0lZ41B599nnxZfSloVTyg==",
             "dependencies": {
-                "@minecraft/server": "1.1.0-beta.preview.1.19.50.21"
+                "@minecraft/server": "1.1.0-beta.1.19.60-preview.26"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1631,16 +1631,16 @@
             "dev": true
         },
         "@minecraft/server": {
-            "version": "1.1.0-beta.preview.1.19.50.21",
-            "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.preview.1.19.50.21.tgz",
-            "integrity": "sha512-ZA/96cHfmRE9RVajlI/HQDmTNiyF4Esjh+xJJ1wto3s1MISkDBlqf2gZbPZdwuRE3cMcONxFDzEXNiHu21FwtQ=="
+            "version": "1.1.0-beta.1.19.60-preview.26",
+            "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-preview.26.tgz",
+            "integrity": "sha512-SR8xaw6tTIAsdJuXcpqYiQd8EAtH8QYQPIKlTjqBZEJcQ8HCBxD5kBAECjYBseTnUIOoJx7UOo7nY7CmvKLjoA=="
         },
         "@minecraft/server-ui": {
-            "version": "1.0.0-beta.preview.1.19.50.21",
-            "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-1.0.0-beta.preview.1.19.50.21.tgz",
-            "integrity": "sha512-/nsa+0NLS4KtgFE9KkVHINEcwwEeGcU8ps09CfOEK36fdS9vaiNNxsssTlncus+Cse6tSGrl02F0sH1LUbh+pQ==",
+            "version": "1.0.0-beta.1.19.60-preview.26",
+            "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-1.0.0-beta.1.19.60-preview.26.tgz",
+            "integrity": "sha512-oZoZlCVh94mgMiQjlmg2aA9b88M0zd4R0QeOJGi/2dhRrhqn1y979SpTlISY4uMeT0lZ41B599nnxZfSloVTyg==",
             "requires": {
-                "@minecraft/server": "1.1.0-beta.preview.1.19.50.21"
+                "@minecraft/server": "1.1.0-beta.1.19.60-preview.26"
             }
         },
         "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "typescript": "^4.7.4"
     },
     "dependencies": {
-        "@minecraft/server": "^1.1.0-beta.11950b23",
-        "@minecraft/server-ui": "^1.0.0-beta.11950b23"
+        "@minecraft/server": "^1.1.0-beta.1.19.60-preview.26",
+        "@minecraft/server-ui": "^1.0.0-beta.1.19.60-preview.26"
     }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,4 +66,4 @@ export default {
 } as const;
 
 // The version of WorldEdit (do not change)
-export const VERSION = "0.7.0";
+export const VERSION = "0.7.1";

--- a/src/library/@types/build/Events.d.ts
+++ b/src/library/@types/build/Events.d.ts
@@ -7,17 +7,16 @@ import {
   BeforeItemUseOnEvent,
   ChatEvent,
   TickEvent,
-  PlayerJoinEvent,
   PlayerLeaveEvent,
   EffectAddEvent,
-  EntityCreateEvent,
   ExplosionEvent,
   PistonActivateEvent,
   WeatherChangeEvent,
   Player,
   Dimension,
   BlockBreakEvent,
-  WorldInitializeEvent
+  WorldInitializeEvent,
+  Entity
 } from "@minecraft/server";
 import { registerInformation } from "./classes/CommandBuilder";
 
@@ -36,7 +35,7 @@ export interface EventList {
     explosion: [ExplosionEvent],
     pistonActivate: [PistonActivateEvent],
     weatherChange: [WeatherChangeEvent],
-    playerJoin: [PlayerJoinEvent],
+    playerJoin: [Player],
     playerLoaded: [PlayerLoadedEvent]
     playerLeave: [PlayerLeaveEvent],
     ready: [ready],
@@ -54,6 +53,12 @@ interface PlayerLoadedEvent {
 interface playerChangeDimension {
     readonly player: Player,
     readonly dimension: Dimension
+}
+export interface EntityCreateEvent { // Equivalent of EntitySpawnEvent (1.19.60+)
+    /**
+     * Entity that was spawned.
+     */
+    entity: Entity;
 }
 interface customCommand {
     registration: registerInformation,

--- a/src/library/@types/build/Events.d.ts
+++ b/src/library/@types/build/Events.d.ts
@@ -35,7 +35,7 @@ export interface EventList {
     explosion: [ExplosionEvent],
     pistonActivate: [PistonActivateEvent],
     weatherChange: [WeatherChangeEvent],
-    playerJoin: [Player],
+    playerJoin: [PlayerJoinEvent],
     playerLoaded: [PlayerLoadedEvent]
     playerLeave: [PlayerLeaveEvent],
     ready: [ready],
@@ -50,6 +50,9 @@ interface ready {
 interface PlayerLoadedEvent {
     readonly player: Player
 }
+interface PlayerJoinEvent {
+    readonly playerName: string
+}
 interface playerChangeDimension {
     readonly player: Player,
     readonly dimension: Dimension
@@ -58,7 +61,7 @@ export interface EntityCreateEvent { // Equivalent of EntitySpawnEvent (1.19.60+
     /**
      * Entity that was spawned.
      */
-    entity: Entity;
+    readonly entity: Entity;
 }
 interface customCommand {
     registration: registerInformation,

--- a/src/library/Minecraft.ts
+++ b/src/library/Minecraft.ts
@@ -302,15 +302,17 @@ class ServerBuild extends ServerBuilder {
     if (events.playerSpawn) {
       events.playerSpawn.subscribe(data => {
         if (data.initialSpawn) {
-          loadingPlayers.push(data.player);
-          this.emit("playerJoin", data.player);
+          this.emit("playerLoaded", data);
         }
+      });
+      events.playerJoin.subscribe(data => {
+        this.emit("playerJoin", { playerName: data.playerName });
       });
     } else { // 1.19.50
       events.playerJoin.subscribe(data => {
         const player = (data as unknown as PlayerSpawnEvent).player;
         loadingPlayers.push(player);
-        this.emit("playerJoin", player);
+        this.emit("playerJoin", { playerName: player.name });
       });
     }
     /**

--- a/src/server/commands/region/smooth_func.ts
+++ b/src/server/commands/region/smooth_func.ts
@@ -3,6 +3,7 @@ import { BlockLocation } from "@minecraft/server";
 import { PlayerSession } from "../../sessions.js";
 import { Shape } from "../../shapes/base_shape.js";
 import { getWorldHeightLimits } from "../../util.js";
+import { RegionBuffer } from "@modules/region_buffer.js";
 
 type map = (number | null)[][];
 
@@ -96,7 +97,7 @@ export function* smooth(session: PlayerSession, iter: number, shape: Shape, loc:
   let count = 0;
   const history = session.getHistory();
   const record = history.record();
-  const warpBuffer = session.createRegion(true);
+  const warpBuffer = new RegionBuffer(true);
   try {
     yield history.addUndoStructure(record, range[0], range[1], "any");
 
@@ -127,7 +128,7 @@ export function* smooth(session: PlayerSession, iter: number, shape: Shape, loc:
     history.cancel(record);
     throw e;
   } finally {
-    session.deleteRegion(warpBuffer);
+    warpBuffer.delete();
   }
 
   return count;

--- a/src/server/commands/region/transform_func.ts
+++ b/src/server/commands/region/transform_func.ts
@@ -5,7 +5,6 @@ import { regionTransformedBounds, Vector } from "@notbeer-api";
 import { Player } from "@minecraft/server";
 import { PlayerSession } from "../../sessions.js";
 import { set } from "./set.js";
-import config from "config.js";
 
 // TODO: fix the bounds sometimes not encompassing the new geometry
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -13,7 +12,7 @@ export function* transformSelection(session: PlayerSession, builder: Player, arg
   assertCuboidSelection(session);
   const history = session.getHistory();
   const record = history.record();
-  const temp = session.createRegion(!config.performanceMode && !session.performanceMode);
+  const temp = session.createRegion(true);
   try {
     const [start, end] = session.selection.getRange();
     const dim = builder.dimension;

--- a/src/server/commands/structure/export.ts
+++ b/src/server/commands/structure/export.ts
@@ -1,7 +1,7 @@
 
 import { assertCanBuildWithin, assertCuboidSelection } from "@modules/assert.js";
 import { PlayerUtil } from "@modules/player_util.js";
-import { contentLog, RawText, regionCenter, regionSize, Server, Vector } from "@notbeer-api";
+import { RawText, regionCenter, regionSize, Server, Vector } from "@notbeer-api";
 import { Player, world } from "@minecraft/server";
 import { registerCommand } from "../register_commands.js";
 
@@ -88,7 +88,7 @@ registerCommand(registerInformation, function* (session, builder, args) {
     Server.structure.delete(namespace + ":weditstructmeta_" + name);
     Server.structure.delete("weditstructref_" + name);
     Server.runCommand(`scoreboard players reset ${struct_name} wedit:exports`);
-    contentLog.debug("error here!");
+
     throw "commands.generic.wedit:commandFail";
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -94,7 +94,7 @@ Server.on("tick", () => {
 });
 
 function makeBuilder(player: Player) {
-  if (hasWorldEdit(player)) {
+  if (hasWorldEdit(player) && !activeBuilders.includes(player)) {
     getSession(player);
     activeBuilders.push(player);
     contentLog.log(`${player.name} has been given worldedit permissions.`);

--- a/src/server/modules/directions.ts
+++ b/src/server/modules/directions.ts
@@ -1,5 +1,6 @@
 import { Player } from "@minecraft/server";
 import { RawText, Vector, CustomArgType } from "@notbeer-api";
+import { getViewVector } from "server/util";
 
 const directions = ["up", "down", "left", "right", "forward", "back", "north", "south", "east", "west", "me"];
 const dirAliases = ["u", "d", "l", "r", "f", "b", "n", "s", "e", "w", "m"];
@@ -59,7 +60,7 @@ export class Cardinal implements CustomArgType {
     if (DIRECTIONS[dirChar]) {
       return DIRECTIONS[dirChar].clone();
     } else {
-      const dir = player.viewVector;
+      const dir = getViewVector(player);
       let cardinal = Vector.ZERO;
       const absDir = [Math.abs(dir.x), Math.abs(dir.y), Math.abs(dir.z)];
       if (absDir[0] > absDir[1] && absDir[0] > absDir[2]) {

--- a/src/server/modules/mask.ts
+++ b/src/server/modules/mask.ts
@@ -131,7 +131,7 @@ export class Mask implements CustomArgType {
       // eslint-disable-next-line no-cond-assign
       while (token = tokens.next()) {
         if (token.type == "id") {
-          out.push(new BlockMask(nodeToken(), parseBlock(tokens, input, false) as parsedBlock));
+          out.push(new BlockMask(nodeToken(), parseBlock(tokens, input, false, true) as parsedBlock));
         } else if (token.value == ",") {
           processOps(out, ops, new ChainMask(token));
         } else if (token.type == "space") {

--- a/src/server/modules/parser.ts
+++ b/src/server/modules/parser.ts
@@ -102,7 +102,7 @@ export function processOps(out: AstNode[], ops: AstNode[], op?: AstNode) {
   }
 }
 
-export function parseBlock(tokens: Tokens, input: string, typeOnly: boolean): parsedBlock|string {
+export function parseBlock(tokens: Tokens, input: string, typeOnly: boolean, isMask = false): parsedBlock|string {
   let typeToken = tokens.curr();
   const block: parsedBlock = {
     id: tokens.curr().value,
@@ -119,7 +119,7 @@ export function parseBlock(tokens: Tokens, input: string, typeOnly: boolean): pa
     if (!blockPerm) {
       throwTokenError(typeToken);
     }
-    if (blockPerm.getProperty("persistent_bit") && !block.states?.has("persistent_bit")) {
+    if (!isMask && blockPerm.getProperty("persistent_bit") && !block.states?.has("persistent_bit")) {
       if (!block.states) {
         block.states = new Map();
       }

--- a/src/server/modules/pattern.ts
+++ b/src/server/modules/pattern.ts
@@ -116,7 +116,7 @@ export class Pattern implements CustomArgType {
     return this.stringObj;
   }
 
-  getPatternInCommand() {
+  getBlockFill() {
     let blockData: parsedBlock;
     if (this.block instanceof BlockPattern) {
       blockData = this.block.block;
@@ -126,20 +126,13 @@ export class Pattern implements CustomArgType {
 
     if (!blockData) return;
 
-    let command = blockData.id;
-    if (blockData.states?.size) {
-      command += "[";
-      let i = 0;
+    const block = MinecraftBlockTypes.get(blockData.id).createDefaultBlockPermutation();
+    if (blockData.states) {
       for (const [state, val] of blockData.states.entries()) {
-        command += `"${state}":`;
-        command += typeof val == "string" ? `"${val}"` : `${val}`;
-        if (i++ < blockData.states.size - 1) {
-          command += ",";
-        }
+        (block.getProperty(state) as AnyBlockProperty).value = val;
       }
-      command += "]";
     }
-    return command;
+    return block;
   }
 
   private compile() {

--- a/src/server/modules/player_util.ts
+++ b/src/server/modules/player_util.ts
@@ -2,6 +2,7 @@ import { Player, Entity, BlockLocation, EntityInventoryComponent } from "@minecr
 import { Server, contentLog } from "@notbeer-api";
 import { Mask } from "./mask.js";
 import config from "config.js";
+import { getViewVector } from "server/util.js";
 
 /**
  * This singleton holds utility and miscellaneous functions for players.
@@ -90,7 +91,7 @@ class PlayerHandler {
    */
   traceForBlock(player: Player, range?: number, mask?: Mask) {
     const start = player.headLocation;
-    const dir = player.viewVector;
+    const dir = getViewVector(player);
     const dim = player.dimension;
 
     let prevPoint = new BlockLocation(Infinity, Infinity, Infinity);

--- a/src/server/modules/region_buffer.ts
+++ b/src/server/modules/region_buffer.ts
@@ -1,6 +1,7 @@
 import { contentLog, generateId, iterateChunk, regionIterateBlocks, regionSize, regionTransformedBounds, regionVolume, Server, StructureLoadOptions, StructureSaveOptions, Thread, Vector } from "@notbeer-api";
-import { Block, BlockLocation, BlockPermutation, BoolBlockProperty, Dimension, EntityCreateEvent, IntBlockProperty, StringBlockProperty } from "@minecraft/server";
-import { blockHasNBTData, locToString, stringToLoc } from "../util.js";
+import { Block, BlockLocation, BlockPermutation, BoolBlockProperty, Dimension, IntBlockProperty, StringBlockProperty } from "@minecraft/server";
+import { blockHasNBTData, getViewVector, locToString, stringToLoc } from "../util.js";
+import { EntityCreateEvent } from "library/@types/build/Events.js";
 
 export interface RegionLoadOptions {
     rotation?: Vector,
@@ -225,7 +226,7 @@ export class RegionBuffer {
           if (shouldTransform) {
             // FIXME: Not properly aligned
             let entityLoc = ev.entity.location;
-            let entityFacing = Vector.from(ev.entity.viewVector).add(entityLoc).toLocation();
+            let entityFacing = Vector.from(getViewVector(ev.entity)).add(entityLoc).toLocation();
 
             entityLoc = Vector.from(entityLoc).sub(loc)
               .rotateY(rotFlip[0].y).rotateX(rotFlip[0].x).rotateZ(rotFlip[0].z)

--- a/src/server/sessions.ts
+++ b/src/server/sessions.ts
@@ -228,7 +228,7 @@ export class PlayerSession {
   }
 
   public createRegion(isAccurate: boolean) {
-    const buffer = new RegionBuffer(isAccurate);
+    const buffer = new RegionBuffer(isAccurate && !config.performanceMode && !this.performanceMode);
     this.regions.set(buffer.id, buffer);
     return buffer;
   }

--- a/src/server/shapes/base_shape.ts
+++ b/src/server/shapes/base_shape.ts
@@ -129,29 +129,30 @@ export abstract class Shape {
         const patternInFill = pattern.getBlockFill();
 
         // eslint-disable-next-line no-constant-condition
-        const fillBlocks = dimension.fillBlocks;
-        if (fillBlocks && this.genVars.isSolidCuboid && patternInFill && (!activeMask || activeMask.empty())) {
+        if (dimension.fillBlocks && this.genVars.isSolidCuboid && patternInFill && (!activeMask || activeMask.empty())) {
           contentLog.debug("Using fillBlocks() method.");
           const size = Vector.sub(max, min).add(1);
           const fillMax = 32;
-          history?.addUndoStructure(record, min, max, "any");
+          yield history?.addUndoStructure(record, min, max, "any");
 
           yield "Calculating shape...";
           yield "Generating blocks...";
-          for (let z = 0; z < size.z; z += fillMax)
-            for (let y = 0; y < size.y; y += fillMax)
+          for (let z = 0; z < size.z; z += fillMax) {
+            for (let y = 0; y < size.y; y += fillMax) {
               for (let x = 0; x < size.x; x += fillMax) {
                 const subStart = Vector.add(min, [x, y, z]);
                 const subEnd = Vector.min(
                   new Vector(x, y, z).add(fillMax), size
                 ).add(min).sub(Vector.ONE);
-                fillBlocks(subStart.toBlock(), subEnd.toBlock(), patternInFill);
+                dimension.fillBlocks(subStart.toBlock(), subEnd.toBlock(), patternInFill);
 
                 const subSize = subEnd.sub(subStart).add(1);
                 count += subSize.x * subSize.y * subSize.z;
                 yield count / (size.x * size.y * size.z);
               }
-          history?.addRedoStructure(record, min, max, "any");
+            }
+          }
+          yield history?.addRedoStructure(record, min, max, "any");
         } else {
           let progress = 0;
           const volume = regionVolume(min, max);

--- a/src/server/tools/stacker_tool.ts
+++ b/src/server/tools/stacker_tool.ts
@@ -5,6 +5,7 @@ import { BlockLocation, Player } from "@minecraft/server";
 import { PlayerSession } from "../sessions.js";
 import { Tool } from "./base_tool.js";
 import { Tools } from "./tool_manager.js";
+import { RegionBuffer } from "@modules/region_buffer.js";
 
 class StackerTool extends Tool {
   public range: number;
@@ -25,7 +26,7 @@ class StackerTool extends Tool {
     }
     const history = session.getHistory();
     const record = history.record();
-    const tempStack = session.createRegion(true);
+    const tempStack = new RegionBuffer(true);
     try {
       yield history.addUndoStructure(record, start, end, "any");
 
@@ -39,7 +40,7 @@ class StackerTool extends Tool {
       history.cancel(record);
       throw e;
     } finally {
-      session.deleteRegion(tempStack);
+      tempStack.delete();
     }
   };
 

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -1,4 +1,4 @@
-import { Block, BlockLocation, Dimension, Location, Player, world } from "@minecraft/server";
+import { Block, BlockLocation, Dimension, Entity, Location, Player, Vector3, world } from "@minecraft/server";
 import { Server, RawText, addTickingArea as addTickArea, removeTickingArea as removeTickArea } from "@notbeer-api";
 import config from "config.js";
 
@@ -30,6 +30,11 @@ export function printerr(msg: string | RawText, player: Player, toActionBar = fa
     msg = <RawText> RawText.translate(msg);
   }
   print(msg.prepend("text", "§c"), player, toActionBar);
+}
+
+export function getViewVector(entity: Entity | Player): Vector3 {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return entity.viewDirection ?? (entity as any).viewVector;
 }
 
 const worldY = new Map<Dimension, [number, number]>();


### PR DESCRIPTION
Both stack and move commands have been upgraded.
- masks can be used with them to specify what blocks to affect.
- entities can be included in these commands.
- You can specify what blocks to be used as placeholder in move. For example. using water as a replacement will replace the blocks moved with water.

1.19.60 support has been added and remains backwards compatible with 1.19.50 this time.
- `;set` command in 1.19.60 has been optimized for operations with single block patterns and cuboid selections.
- This also affects operations that perform a similar task within, such as the filling of air after cutting a region.

Also, the version has been bumped to 0.7.1.