### PR TITLE
Fix ticking areas not being removed in other dimensions

### DIFF
--- a/src/library/utils/tickingarea.ts
+++ b/src/library/utils/tickingarea.ts
@@ -7,7 +7,7 @@ export async function addTickingArea(start: BlockLocation, end: BlockLocation, d
   ).then(result => result.error);
 }
 
-export async function removeTickingArea(name: string) {
-  return Server.runCommand(`tickingarea remove ${name}`)
+export async function removeTickingArea(name: string, dimension: Dimension) {
+  return Server.runCommand(`tickingarea remove ${name}`, dimension)
     .then(result => result.error);
 }

--- a/src/server/modules/history.ts
+++ b/src/server/modules/history.ts
@@ -211,7 +211,7 @@ export class History {
           throw new UnloadedChunksError("worldedit.error.loadHistory");
         }
       } finally {
-        await removeTickingArea(tickArea);
+        await removeTickingArea(tickArea, region.dimension);
       }
     }
 

--- a/src/server/modules/history.ts
+++ b/src/server/modules/history.ts
@@ -167,7 +167,7 @@ export class History {
           throw new UnloadedChunksError("worldedit.error.loadHistory");
         }
       } finally {
-        await removeTickingArea(tickArea);
+        await removeTickingArea(tickArea, region.dimension);
       }
     }
 

--- a/src/server/modules/jobs.ts
+++ b/src/server/modules/jobs.ts
@@ -1,5 +1,5 @@
 import { Server, RawText, contentLog } from "@notbeer-api";
-import { BlockLocation, Player } from "@minecraft/server";
+import { BlockLocation, Player, Dimension } from "@minecraft/server";
 import { PlayerSession } from "server/sessions";
 import { addTickingArea, removeTickingArea } from "server/util";
 
@@ -12,7 +12,8 @@ interface job {
     player: Player,
     message: string,
     percent: number,
-    area: string
+    area: string,
+    dimension: Dimension
 }
 
 class JobHandler {
@@ -35,7 +36,8 @@ class JobHandler {
       player: session.getPlayer(),
       message: "",
       percent: 0,
-      area: areaName
+      area: areaName,
+      dimension: session.getPlayer().dimension
     });
     return jobId;
   }
@@ -86,7 +88,7 @@ class JobHandler {
       job.percent = 1;
       job.step = job.stepCount - 1;
       job.message = "Finished!"; // TODO: Localize
-      removeTickingArea(job.area);
+      removeTickingArea(job.area, job.dimension);
 
       this.printJobs();
       this.jobs.delete(jobId);

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -170,7 +170,7 @@ const readyListener = async () => {
   }
   setTickingAreas([]);
 };
-if (!Server.listeners("ready").map(fn => fn.toString()).includes(readyListener.toString())) {
+if (!Server.listeners("ready").map(fn => `${fn}`).includes(`${readyListener}`)) {
   Server.on("ready", readyListener);
 }
 

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -149,12 +149,12 @@ export async function addTickingArea(name: string, dim: Dimension, start: BlockL
   return true;
 }
 
-export async function removeTickingArea(name: string) {
+export async function removeTickingArea(name: string, dim: Dimension) {
   const tickingAreas = getTickingAreas();
   if (!tickingAreas.includes(name)) {
     return true;
   }
-  if(!await removeTickArea(name)) {
+  if(!await removeTickArea(name, dim)) {
     setTickingAreas(tickingAreas.splice(tickingAreas.indexOf(name)));
     return false;
   }

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -155,16 +155,18 @@ export async function removeTickingArea(name: string, dim: Dimension) {
     return true;
   }
   if(!await removeTickArea(name, dim)) {
-    setTickingAreas(tickingAreas.splice(tickingAreas.indexOf(name)));
+    tickingAreas.splice(tickingAreas.indexOf(name), 1);
+    setTickingAreas(tickingAreas);
     return false;
   }
   return true;
 }
 
-Server.on("ready", () => {
+Server.on("ready", async () => {
   for (const tickingArea of getTickingAreas()) {
+    if (!tickingArea) continue;
     for (const dim of ["overworld", "nether", "the_end"]) {
-      if (!removeTickArea(tickingArea, world.getDimension(dim))) break;
+      if (!await removeTickArea(tickingArea, world.getDimension(dim))) break;
     }
   }
   setTickingAreas([]);

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -162,7 +162,7 @@ export async function removeTickingArea(name: string, dim: Dimension) {
   return true;
 }
 
-Server.on("ready", async () => {
+const readyListener = async () => {
   for (const tickingArea of getTickingAreas()) {
     if (!tickingArea) continue;
     for (const dim of ["overworld", "nether", "the_end"]) {
@@ -170,7 +170,10 @@ Server.on("ready", async () => {
     }
   }
   setTickingAreas([]);
-});
+};
+if (!Server.listeners("ready").map(fn => fn.toString()).includes(readyListener.toString())) {
+  Server.on("ready", readyListener); 
+}
 
 /**
  * Converts a location object to a string.

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -172,7 +172,7 @@ const readyListener = async () => {
   setTickingAreas([]);
 };
 if (!Server.listeners("ready").map(fn => fn.toString()).includes(readyListener.toString())) {
-  Server.on("ready", readyListener); 
+  Server.on("ready", readyListener);
 }
 
 /**

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -163,7 +163,7 @@ export async function removeTickingArea(name: string, dim: Dimension) {
 
 Server.on("ready", () => {
   for (const tickingArea of getTickingAreas()) {
-    for (dim of ["overworld", "nether", "the_end"]) {
+    for (const dim of ["overworld", "nether", "the_end"]) {
       if (!removeTickArea(tickingArea, world.getDimension(dim))) break;
     }
   }

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -155,8 +155,7 @@ export async function removeTickingArea(name: string, dim: Dimension) {
     return true;
   }
   if(!await removeTickArea(name, dim)) {
-    tickingAreas.splice(tickingAreas.indexOf(name), 1);
-    setTickingAreas(tickingAreas);
+    setTickingAreas(tickingAreas.filter(tickingArea => tickingArea !== name));
     return false;
   }
   return true;

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -163,7 +163,9 @@ export async function removeTickingArea(name: string, dim: Dimension) {
 
 Server.on("ready", () => {
   for (const tickingArea of getTickingAreas()) {
-    removeTickArea(tickingArea);
+    for (dim of ["overworld", "nether", "the_end"]) {
+      if (!removeTickArea(tickingArea, world.getDimension(dim))) break;
+    }
   }
   setTickingAreas([]);
 });


### PR DESCRIPTION
The `/tickingarea` command can only modify ticking areas in the dimension that it is executed in, which causes the bug described below. This pull request fixes it by adding a dimension parameter to the `removeTickingArea` function. Some additional bugs related to ticking areas were fixed too.

### Current behavior

Ticking areas do not get removed after using WorldEdit in the nether or the end.

###  Expected behavior

Ticking areas should get removed regardless of which dimension they are in.

### Steps to reproduce

1. Go to the nether or end
2. Perform WorldEdit operations
3. Run `/tickingarea list`
