### PR TITLE
Upgrade item format version to stable 1.20.10

### DIFF
--- a/BP/items/buttons/config.item.json
+++ b/BP/items/buttons/config.item.json
@@ -12,7 +12,8 @@
             "minecraft:display_name": {
                 "value": "worldedit.config.mainMenu"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/config.item.json
+++ b/BP/items/buttons/config.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:config_button",
@@ -7,18 +7,12 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "config",
-                "frame": "0"
+                "texture": "config"
             },
             "minecraft:display_name": {
                 "value": "worldedit.config.mainMenu"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/copy.item.json
+++ b/BP/items/buttons/copy.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "copy"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/copy.item.json
+++ b/BP/items/buttons/copy.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:copy_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "copy",
-                "frame": "0"
+                "texture": "copy"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/cut.item.json
+++ b/BP/items/buttons/cut.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "cut"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/cut.item.json
+++ b/BP/items/buttons/cut.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:cut_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "cut",
-                "frame": "0"
+                "texture": "cut"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/draw_line.item.json
+++ b/BP/items/buttons/draw_line.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:draw_line",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "draw_line",
-                "frame": "0"
+                "texture": "draw_line"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/draw_line.item.json
+++ b/BP/items/buttons/draw_line.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "draw_line"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/flip.item.json
+++ b/BP/items/buttons/flip.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "flip"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/flip.item.json
+++ b/BP/items/buttons/flip.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:flip_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "flip",
-                "frame": "0"
+                "texture": "flip"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/mask_picker.item.json
+++ b/BP/items/buttons/mask_picker.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "maskdropper"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/mask_picker.item.json
+++ b/BP/items/buttons/mask_picker.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:mask_picker",
@@ -7,16 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "maskdropper",
-                "frame": "0"
+                "texture": "maskdropper"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:liquid_clipped": true,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/paste.item.json
+++ b/BP/items/buttons/paste.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:paste_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "paste",
-                "frame": "0"
+                "texture": "paste"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/paste.item.json
+++ b/BP/items/buttons/paste.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "paste"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/pattern_picker.item.json
+++ b/BP/items/buttons/pattern_picker.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "eyedropper"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/pattern_picker.item.json
+++ b/BP/items/buttons/pattern_picker.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:pattern_picker",
@@ -7,16 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "eyedropper",
-                "frame": "0"
+                "texture": "eyedropper"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:liquid_clipped": true,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/redo.item.json
+++ b/BP/items/buttons/redo.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "redo"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/redo.item.json
+++ b/BP/items/buttons/redo.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:redo_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "redo",
-                "frame": "0"
+                "texture": "redo"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/rotate_ccw.item.json
+++ b/BP/items/buttons/rotate_ccw.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:rotate_ccw_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "rotate_ccw",
-                "frame": "0"
+                "texture": "rotate_ccw"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/rotate_ccw.item.json
+++ b/BP/items/buttons/rotate_ccw.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "rotate_ccw"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/rotate_cw.item.json
+++ b/BP/items/buttons/rotate_cw.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "rotate_cw"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/rotate_cw.item.json
+++ b/BP/items/buttons/rotate_cw.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:rotate_cw_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "rotate_cw",
-                "frame": "0"
+                "texture": "rotate_cw"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/selection_fill.item.json
+++ b/BP/items/buttons/selection_fill.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "selection_fill"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/selection_fill.item.json
+++ b/BP/items/buttons/selection_fill.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:selection_fill",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "selection_fill",
-                "frame": "0"
+                "texture": "selection_fill"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/selection_outline.item.json
+++ b/BP/items/buttons/selection_outline.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "selection_outline"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/selection_outline.item.json
+++ b/BP/items/buttons/selection_outline.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:selection_outline",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "selection_outline",
-                "frame": "0"
+                "texture": "selection_outline"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/selection_wall.item.json
+++ b/BP/items/buttons/selection_wall.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:selection_wall",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "selection_wall",
-                "frame": "0"
+                "texture": "selection_wall"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/selection_wall.item.json
+++ b/BP/items/buttons/selection_wall.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "selection_wall"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/spawn_glass.item.json
+++ b/BP/items/buttons/spawn_glass.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "spawn_glass"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/spawn_glass.item.json
+++ b/BP/items/buttons/spawn_glass.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:spawn_glass",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "spawn_glass",
-                "frame": "0"
+                "texture": "spawn_glass"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/buttons/undo.item.json
+++ b/BP/items/buttons/undo.item.json
@@ -9,7 +9,8 @@
             "minecraft:icon": {
                 "texture": "undo"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/buttons/undo.item.json
+++ b/BP/items/buttons/undo.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:undo_button",
@@ -7,15 +7,9 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "undo",
-                "frame": "0"
+                "texture": "undo"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/ui/blank.item.json
+++ b/BP/items/ui/blank.item.json
@@ -12,7 +12,8 @@
             "minecraft:display_name": {
                 "value": " "
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/ui/blank.item.json
+++ b/BP/items/ui/blank.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:blank",
@@ -7,18 +7,12 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "blank",
-                "frame": "0"
+                "texture": "blank"
             },
             "minecraft:display_name": {
                 "value": " "
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/ui/cancel.item.json
+++ b/BP/items/ui/cancel.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:cancel_button",
@@ -7,18 +7,12 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "cancel",
-                "frame": "0"
+                "texture": "cancel"
             },
             "minecraft:display_name": {
                 "value": "gui.back"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/ui/cancel.item.json
+++ b/BP/items/ui/cancel.item.json
@@ -12,7 +12,8 @@
             "minecraft:display_name": {
                 "value": "gui.back"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }

--- a/BP/items/ui/confirm.item.json
+++ b/BP/items/ui/confirm.item.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.16.100",
+    "format_version": "1.20.10",
     "minecraft:item": {
         "description": {
             "identifier": "wedit:confirm_button",
@@ -7,18 +7,12 @@
         },
         "components": {
             "minecraft:icon": {
-                "texture": "confirm",
-                "frame": "0"
+                "texture": "confirm"
             },
             "minecraft:display_name": {
                 "value": "dr.button.ok"
             },
-            "minecraft:max_stack_size": 1,
-            "minecraft:on_use": {
-                "on_use": {
-                    "event": "empty"
-                }
-            }
+            "minecraft:max_stack_size": 1
         }
     }
 }

--- a/BP/items/ui/confirm.item.json
+++ b/BP/items/ui/confirm.item.json
@@ -12,7 +12,8 @@
             "minecraft:display_name": {
                 "value": "dr.button.ok"
             },
-            "minecraft:max_stack_size": 1
+            "minecraft:max_stack_size": 1,
+            "minecraft:throwable": {}
         }
     }
 }


### PR DESCRIPTION
Changed item JSON files to use the 1.20.10 stable components, thus making the addon not require Holiday Creator Features anymore in game versions of 1.20.10 or greater. Changed the following:

1. Removed unused/empty minecraft:on_use component in item JSON files.
2. Removed minecraft:liquid_clipped from items as this component is going to be deprecated and removed from the game (see https://discord.com/channels/523663022053392405/1115783093895319672 in bedrock addons).
3. Removed frame from the texture component since it is not needed.