### PR TITLE
Update main.yml to Use Node.js 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,13 +27,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: montudor/action-zip@v1
       - uses: bahmutov/npm-install@v1
         with:
-          node-version: 12
-      - uses: actions/setup-python@v2
+          node-version: 16
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.x'
       
@@ -47,14 +47,14 @@ jobs:
         run: python build.py --clean --target ${{ matrix.target }}
       
       - name: Archive addon artifact (release)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.target == 'release'}}
         with:
           name: mcaddon-artifact-release
           path: builds/WorldEdit.mcaddon
       
       - name: Archive addon artifact (debug)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.target == 'debug'}}
         with:
           name: mcaddon-artifact-debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       
       - uses: montudor/action-zip@v1
       - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
This updates the main.yml workflow file to use the newer versions of actions, in order to use Node.js 16, instead of Node.js 12. This is because Node.js 12 will reach end of support soon on GitHub Actions.