### PR TITLE
Added fallback when variable.json is not detected

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,12 +2,6 @@ import { Player, world } from "@minecraft/server";
 import { print, printerr } from "./util.js";
 import isWhitelistEnabled from "whitelist.js";
 
-// Check if configuration is properly loaded
-if (!config.commandPrefix) {
-    world.getAllPlayers().forEach((player) => printerr("WorldEdit failed to load configuration!", player, false));
-    throw new Error('Configuration is not properly loaded! If this is a server, "variables.json" is required.');
-}
-
 import { contentLog, Server, configuration } from "@notbeer-api";
 import { getSession, removeSession } from "./sessions.js";
 import { PlayerUtil } from "@modules/player_util.js";

--- a/tools/process_config.py
+++ b/tools/process_config.py
@@ -45,7 +45,12 @@ def generateScript(isServer):
     result += "export default {\n"
     for name, data in settings.items():
         if isServer:
-            result += f'  {name}: variables.get("{name}"),\n'
+            variable = data["default"]
+            if type(data["default"]) is bool:
+                variable = "true" if data["default"] else "false"
+            elif type(data["default"]) is str:
+                variable = f'"{data["default"]}"'
+            result += f'  {name}: variables.get("{name}") || {variable},\n'
         else:
             value = data["default"]
 


### PR DESCRIPTION
Due to Aternos not allowing the upload of variables.json to the config/default directory, I implemented fallback values to ensure functionality without the file. Additionally, I removed the check for the presence of variables.json too. It’s worth to update the documentation regarding Aternos to include inability to upload variables.json. 