### PR TITLE
fix: simulated players is undefined in world.getPlayers()

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,7 +34,8 @@ Server.on("playerLeave", (ev) => {
 Server.on("tick", () => {
     if (!ready) return;
 
-    for (const player of world.getPlayers()) {
+    const realPlayers = world.getPlayers().filter((p) => p != undefined);
+    for (const player of realPlayers) {
         if (!activeBuilders.includes(player)) {
             if (PlayerUtil.isHotbarStashed(player)) {
                 PlayerUtil.restoreHotbar(player);


### PR DESCRIPTION
Resolves #286 
For simulated players created by other packages, they would be recognized as `undefined` in this addon.