### PR TITLE
Update contributing documentation

### DIFF
--- a/BP/scripts/README.txt
+++ b/BP/scripts/README.txt
@@ -1,1 +1,1 @@
-The files in this folder must be generated with the build script in the root directory (build.py).
+The files in this folder must be generated with the build script in the root directory (build.mjs).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,22 @@
 # Contributing to WorldEdit
 
-If you're thinking of contributing to WorldEdit, you've come to the right page! There are many ways you can help with the development of this addon.
+If you're thinking of contributing to WorldEdit, then you've come to the right page! There are many ways you can help with the development of this addon.
 
 ## Reporting bugs
 
-If you've encountered a bug with the addon, please go [here](https://github.com/SIsilicon/WorldEdit-BE/issues/new?template=bug_report.md) to submit one. When reporting a bug, you must:
+If you've encountered a bug with the addon, please go [here](https://github.com/SIsilicon/WorldEdit-BE/issues/new?template=bug_report.yml) to submit one. When reporting a bug, you must:
 - Make sure the bug has not been reported before
 - Be descriptive about the bug and what caused to appear
 - If applicable, provide content logs for more detail about the addon usage.
 
-To get content logs, you must first enable it from `Settings > Creator`.
+To get content logs, you must first enable it from `Settings > Creator`. If you're not sure how to do this, see [this tutorial](https://learn.microsoft.com/minecraft/creator/documents/contenterrorlog).
 
 ## Giving feedback
 
 The aim of this project is to replicate as many of the original WorldEdit features as possible, so if there's a feature you want that's in the original mod, it will likely be implemented anyway if possible.
 However, you can still propose features that _aren't_ in the original mod, so long as you can make a case for how useful it can be. Then the proposal will be considered.
 
-You submit proposals [here](https://github.com/SIsilicon/WorldEdit-BE/issues/new?template=feature_request.md). Make sure that a similar proposal has not been made already.
+You submit proposals [here](https://github.com/SIsilicon/WorldEdit-BE/issues/new?template=feature_request.yml). Make sure that a similar proposal has not been made already.
 
 ## Contributing code
 
@@ -24,25 +24,39 @@ This addon is not like most other addons. It takes more resources to get it func
 
 - Windows 10 and up
 - Git (and the knowledge of using it)
-- Python 3 and up
-- Node package manager
+- Node.js
+- npm
 
-It's recommended to have a code editor, such as Vscode, to easily modify the code.
+It's recommended you have a code editor, such as [VS Code](https://code.visualstudio.com/), to easily modify the code.
 
 ### Preparations
 
-First, you need to use Git and pull this project from GitHub. To do so, run the command `[TODO]` from the command line, the current working directory is where this project will appear. After you got all the files pulled, the next step is to install node dependencies with the command `npm install`.
+First, ensure you have installed [Git](https://git-scm.com/install), along with [Node.js and npm](https://nodejs.org/en/download), following the respective instructions.
+
+Run this command in the folder where you want the project to go:
+```cmd
+git clone https://github.com/SIsilicon/WorldEdit-BE
+```
+
+Next, change into the project folder and install the node dependencies:
+
+```cmd
+cd WorldEdit-BE
+npm install
+```
 
 ### Building
 
-Once that's all set up, you can now start building! The file responsible for this is `build.py`. It comes with many parameters when building the addon.
+Once that's all set up, you can now start building! The file responsible for this is `build.mjs`. It comes with many parameters when building the addon.
 
 - `--watch, -w`: Defining this parameter puts the project in watch mode.
-- `--target`: Defines the kind of build to make. The addon has three modes. `release`, `debug`, and `release_server`. Does not work when in watch mode.
+- `--target`: Defines the kind of build to make. The addon has three modes. `release`, `debug`, and `server`. Does not work when in watch mode.
 - `--clean, -c`: Whether to clear the scripts folder before building. This folder contains the build result of the source typescript files.
 - `--package-only, -p`: Only package what's already built.
 
-So whenever you want to build the addon, all you have to do is run this script (`python build.py "parameters"`). Once built, the result will be inside the `builds` folder.
+So whenever you want to build the addon, all you have to do is run the script with Node (`node build.mjs "parameters"`). Once built, the result will be inside the `builds` folder.
+
+You can also run premade scripts, which are defined in the `package.json` file. For example, to build a beta version, run `npm run build:beta`.
 
 ### Watch mode
 
@@ -52,25 +66,10 @@ When in watch mode, the addon builds its scripts and language files every time t
 - `preview`: Sync with the preview version of Minecraft
 - `server`: Sync with a Bedrock Dedicated Server
 
-For that last one, you'll need to specify the location of the server at `tools/sync2com-mojang.py`.
+For that last one, you'll need to specify the location of the server in the command: `npm run watch:server -- --server <path>`
 
 One more thing. While changing scripts, you can run the command `/reload` ingame to reload them, without having to exit and enter the world.
 
-### Linting
-
-#### Python
-
-The `isort` and `black` packages found in the `requirements.txt` file are responsible for automatically formatting your Python code!
-
-Simply run these commands locally at the root of the repository to automatically format the Python code:
-``` bash
-# Sort package imports.
-isort --profile black .
-
-# Auto-format Python code.
-black .
-```
-
 ## Translations
 
-Speak another language? Help the addon become more localized by going to the addon's [Crowdin page](https://crowdin.com/project/worldedit-for-bedrock). Choose a language you're good with, and start contributing in places that don't have a translation.
+Speak another language? Help the addon support more languages by going to the addon's [Crowdin page](https://crowdin.com/project/worldedit-for-bedrock). Choose a language you're good with, and start contributing in places that don't have a translation.

--- a/build.mjs
+++ b/build.mjs
@@ -96,7 +96,7 @@ if (!fs.existsSync(scriptOutputDir)) throw "The output scripts folder does not e
 
 // Calculate sync location when in fs.watch mode.
 if (args.watch === "stable") {
-    args.syncDir = env.LOCALAPPDATA + "\\Packages\\Microsoft.MinecraftUWP_8wekyb3d8bbwe\\LocalState\\games\\com.mojang";
+    args.syncDir = env.APPDATA + "\\Minecraft Bedrock\\Users\\Shared\\games\\com.mojang";
 } else if (args.watch === "preview") {
     args.syncDir = env.APPDATA + "\\Minecraft Bedrock Preview\\Users\\Shared\\games\\com.mojang";
 } else if (args.watch === "server") {

--- a/texts/README.md
+++ b/texts/README.md
@@ -1,5 +1,5 @@
 # Translation
 
-Minecraft only understands ".lang" files when looking for text to use in the game. ".po" files are used here since they are more standard, and they are converted to ".lang" with [po2lang.py](../po2lang.py) when the project is built.
+Minecraft only understands `.lang` files when looking for text to use in the game. `.po` files are used here since they are more standard, and they are converted to `.lang` with [po2lang.mjs](../tools/po2lang.mjs) when the project is built.
 
 The main language used is English (US) in [en_US.po](en_US.po). If you want to contribute your own translations, please do so from the project's Crowdin page: https://crowdin.com/project/worldedit-for-bedrock


### PR DESCRIPTION
## Changes
This PR updates the contributing documentation.

It also changes the `build.mjs` script to use the GDK path when watching `stable`.